### PR TITLE
feat: JWT 토큰 발급 API 및 로그인 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-application-aws-s3.yml
+application-secret-key.yml
 
 ### NetBeans ###
 /nbproject/private/

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/gatheringhaja/controller/AuthController.java
+++ b/src/main/java/com/example/gatheringhaja/controller/AuthController.java
@@ -25,7 +25,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody @Valid SignInMemberRequest signInMemberRequest) {
+    public ResponseEntity<String> login(@RequestBody @Valid SignInMemberRequest signInMemberRequest) {
         return ResponseEntity.ok().body(authService.signIn(signInMemberRequest));
     }
 

--- a/src/main/java/com/example/gatheringhaja/dto/request/SignInMemberRequest.java
+++ b/src/main/java/com/example/gatheringhaja/dto/request/SignInMemberRequest.java
@@ -1,0 +1,16 @@
+package com.example.gatheringhaja.dto.request;
+
+import jakarta.validation.constraints.Email;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignInMemberRequest {
+
+    @Email
+    private String email;
+
+    private String password;
+
+}

--- a/src/main/java/com/example/gatheringhaja/exception/ErrorCode.java
+++ b/src/main/java/com/example/gatheringhaja/exception/ErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다.");
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
+    NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "해당하는 이메일을 찾을 수 없습니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "입력한 비밀번호가 일치 하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/gatheringhaja/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/gatheringhaja/exception/GlobalExceptionHandler.java
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(DuplicateEmailException.class)
-    public ResponseEntity<ErrorResponse> duplicateEmailExceptionHandler(DuplicateEmailException e) {
+    @ExceptionHandler(MeetingHaJaException.class)
+    public ResponseEntity<ErrorResponse> MeetingHaJaExceptionHandler(MeetingHaJaException e) {
         return ErrorResponse.errorResponse(e.getErrorCode());
     }
 

--- a/src/main/java/com/example/gatheringhaja/exception/MeetingHaJaException.java
+++ b/src/main/java/com/example/gatheringhaja/exception/MeetingHaJaException.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class DuplicateEmailException extends RuntimeException {
+public class MeetingHaJaException extends RuntimeException {
 
     private ErrorCode errorCode;
 

--- a/src/main/java/com/example/gatheringhaja/util/JwtTokenUtil.java
+++ b/src/main/java/com/example/gatheringhaja/util/JwtTokenUtil.java
@@ -1,0 +1,22 @@
+package com.example.gatheringhaja.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import java.util.Date;
+
+public class JwtTokenUtil {
+
+    public static String createToken(String email, String key, long expireTimeMs) {
+        Claims claims = Jwts.claims();
+        claims.put("email", email);
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expireTimeMs))
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
+    }
+
+}

--- a/src/main/resources/application-secret-key.yml
+++ b/src/main/resources/application-secret-key.yml
@@ -6,5 +6,10 @@ cloud:
       stack.auto: false
       region.static: us-east-1
       credentials:
-        accessKey: AKIAQQTPC6YH6JVNTDID
-        secretKey: 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
+        accessKey: "accessKey"
+        secretKey: "secretKey"
+
+# JWT
+jwt:
+  token:
+    secret: "secretKey"


### PR DESCRIPTION
### 변경사항
**TO-BE**
1. AuthController
- login API 반환 타입 변경
2. AuthService
- signIn API 기능 추가
- 가입된 이메일 인지 & 가입한 패스워드와 로그인 할 때 패스워드가 일치하는지 코드 추가
3. ErrorCode
- status 코드 추가

### 테스트
- [x] API 테스트 