### PR TITLE
feat: 모임 삭제 API

### DIFF
--- a/src/main/java/com/example/gatheringhaja/controller/MeetingController.java
+++ b/src/main/java/com/example/gatheringhaja/controller/MeetingController.java
@@ -1,5 +1,6 @@
 package com.example.gatheringhaja.controller;
 
+import com.example.gatheringhaja.dto.MessageResponse;
 import com.example.gatheringhaja.dto.request.CreateMeetingRequest;
 import com.example.gatheringhaja.dto.request.UpdateMeetingRequest;
 import com.example.gatheringhaja.dto.response.CreateMeetingResponse;
@@ -9,6 +10,7 @@ import com.example.gatheringhaja.dto.response.UpdateMeetingResponse;
 import com.example.gatheringhaja.service.MeetingService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -40,6 +42,12 @@ public class MeetingController {
     public ResponseEntity<UpdateMeetingResponse> update(@PathVariable("meetingId") Long meetingId,
                                                         @RequestBody @Valid UpdateMeetingRequest updateMeetingRequest) {
         return ResponseEntity.ok(meetingService.update(meetingId, updateMeetingRequest));
+    }
+
+    @DeleteMapping("/{meetingId}")
+    public ResponseEntity<MessageResponse> delete(@PathVariable("meetingId") Long meetingId) {
+        meetingService.delete(meetingId);
+        return new ResponseEntity<>(MessageResponse.from(MessageResponse.MEETING_DELETED), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/gatheringhaja/controller/MemberController.java
+++ b/src/main/java/com/example/gatheringhaja/controller/MemberController.java
@@ -1,12 +1,12 @@
 package com.example.gatheringhaja.controller;
 
+import com.example.gatheringhaja.dto.MessageResponse;
 import com.example.gatheringhaja.dto.request.UpdateMemberRequest;
 import com.example.gatheringhaja.dto.response.FindAllMeetingResponse;
 import com.example.gatheringhaja.dto.response.FindAllMemberResponse;
 import com.example.gatheringhaja.dto.response.FindByIdMemberResponse;
 import com.example.gatheringhaja.dto.response.UpdateMemberResponse;
 import com.example.gatheringhaja.service.MemberService;
-import com.example.gatheringhaja.util.MessageConstants;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -45,9 +45,9 @@ public class MemberController {
     }
 
     @DeleteMapping("/{memberId}")
-    public ResponseEntity<String> delete(@PathVariable("memberId") Long memberId) {
+    public ResponseEntity<MessageResponse> delete(@PathVariable("memberId") Long memberId) {
         memberService.delete(memberId);
-        return new ResponseEntity<>(MessageConstants.MEMBER_DELETED, HttpStatus.OK);
+        return new ResponseEntity<>(MessageResponse.from(MessageResponse.MEMBER_DELETED), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/gatheringhaja/dto/MessageResponse.java
+++ b/src/main/java/com/example/gatheringhaja/dto/MessageResponse.java
@@ -1,0 +1,23 @@
+package com.example.gatheringhaja.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MessageResponse {
+
+    private String message;
+
+    public static final String MEMBER_DELETED = "회원이 삭제되었습니다.";
+    public static final String MEETING_DELETED = "모임이 삭제되었습니다.";
+
+    public static MessageResponse from(String message) {
+        return MessageResponse.builder()
+                .message(message)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/gatheringhaja/service/MeetingService.java
+++ b/src/main/java/com/example/gatheringhaja/service/MeetingService.java
@@ -55,4 +55,14 @@ public class MeetingService {
         return UpdateMeetingResponse.from(meetingRepository.save(meeting));
     }
 
+    @Transactional
+    public void delete(Long meetingId) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new MeetingExceptionHandler(ErrorCode.NOT_FOUND_MEETING));
+        if (!meeting.getMember().getId().equals(meetingId)) {
+            throw new MeetingExceptionHandler(ErrorCode.NO_AUTHORITY);
+        }
+        meetingRepository.delete(meeting);
+    }
+
 }

--- a/src/main/java/com/example/gatheringhaja/util/MessageConstants.java
+++ b/src/main/java/com/example/gatheringhaja/util/MessageConstants.java
@@ -1,7 +1,0 @@
-package com.example.gatheringhaja.util;
-
-public class MessageConstants {
-
-    public static final String MEMBER_DELETED = "회원이 삭제되었습니다.";
-
-}


### PR DESCRIPTION
### 변경사항
- MeetingController & MeetingService 클래스에 모임 삭제 API 추가
- MemberController 클래스에 delete() 반환타입 수정
- 삭제 기능 json 타입으로 전달 하기 위해 MessageResponse 클래스 추가
### 테스트
- [x] API 테스트 