### PR TITLE
feat: 댓글 수정 기능 추가

### DIFF
--- a/src/main/java/com/example/gatheringhaja/controller/MeetingController.java
+++ b/src/main/java/com/example/gatheringhaja/controller/MeetingController.java
@@ -3,6 +3,7 @@ package com.example.gatheringhaja.controller;
 import com.example.gatheringhaja.dto.MessageResponse;
 import com.example.gatheringhaja.dto.request.CreateCommentRequest;
 import com.example.gatheringhaja.dto.request.CreateMeetingRequest;
+import com.example.gatheringhaja.dto.request.UpdateCommentRequest;
 import com.example.gatheringhaja.dto.request.UpdateMeetingRequest;
 import com.example.gatheringhaja.dto.response.*;
 import com.example.gatheringhaja.service.MeetingService;
@@ -52,6 +53,13 @@ public class MeetingController {
     public ResponseEntity<CreateCommentResponse> createComment(@PathVariable("meetingId") Long meetingId,
                                                                @RequestBody @Valid CreateCommentRequest createCommentRequest) {
         return ResponseEntity.ok(meetingService.createComment(meetingId, createCommentRequest));
+    }
+
+    @PutMapping("/{meetingId}/{commentId}")
+    public ResponseEntity<UpdateCommentResponse> updateComment(@PathVariable("meetingId") Long meetingId,
+                                                               @PathVariable("commentId") Long commentId,
+                                                               @RequestBody @Valid UpdateCommentRequest updateCommentRequest) {
+        return ResponseEntity.ok(meetingService.updateComment(meetingId, commentId, updateCommentRequest));
     }
 
 }

--- a/src/main/java/com/example/gatheringhaja/dto/request/UpdateCommentRequest.java
+++ b/src/main/java/com/example/gatheringhaja/dto/request/UpdateCommentRequest.java
@@ -1,0 +1,22 @@
+package com.example.gatheringhaja.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class UpdateCommentRequest {
+
+    @Size(min = 5, message = "내용은 최소 5자 이상 입력해주세요.")
+    private String content;
+
+    @NotNull(message = "사용자 ID는 null 일 수 없습니다.")
+    private Long memberId;
+
+}

--- a/src/main/java/com/example/gatheringhaja/dto/response/UpdateCommentResponse.java
+++ b/src/main/java/com/example/gatheringhaja/dto/response/UpdateCommentResponse.java
@@ -1,4 +1,4 @@
-package com.example.gatheringhaja.dto;
+package com.example.gatheringhaja.dto.response;
 
 import com.example.gatheringhaja.entity.Comment;
 import lombok.AllArgsConstructor;
@@ -12,24 +12,20 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CommentPayload {
-
-    public static final boolean DEFAULT_IS_UPDATED = false;
+public class UpdateCommentResponse {
 
     private Long id;
     private String content;
     private boolean isUpdated;
-    private Long meetingId;
     private Long memberId;
     private LocalDate created;
     private LocalDate updated;
 
-    public static CommentPayload from(Comment comment) {
-        return CommentPayload.builder()
+    public static UpdateCommentResponse from(Comment comment) {
+        return UpdateCommentResponse.builder()
                 .id(comment.getId())
                 .content(comment.getContent())
-                .isUpdated(DEFAULT_IS_UPDATED)
-                .meetingId(comment.getMeeting().getId())
+                .isUpdated(comment.isUpdated())
                 .memberId(comment.getMemberId())
                 .created(comment.getCreated())
                 .updated(comment.getUpdated())

--- a/src/main/java/com/example/gatheringhaja/entity/Meeting.java
+++ b/src/main/java/com/example/gatheringhaja/entity/Meeting.java
@@ -1,7 +1,10 @@
 package com.example.gatheringhaja.entity;
 
+import com.example.gatheringhaja.dto.request.UpdateCommentRequest;
 import com.example.gatheringhaja.dto.request.UpdateMeetingRequest;
 import com.example.gatheringhaja.entity.enumerations.MeetingType;
+import com.example.gatheringhaja.exception.ErrorCode;
+import com.example.gatheringhaja.exception.meeting.MeetingExceptionHandler;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -82,6 +85,32 @@ public class Meeting extends BaseTimeEntity {
     public void addComments(Comment comment) {
         comment.setMeeting(this);
         this.comments.add(comment);
+    }
+
+    public Comment getLatestComment() {
+        return comments.stream()
+                .reduce((first, second) -> second)
+                .orElseThrow(() -> new MeetingExceptionHandler(ErrorCode.NOT_FOUND_COMMENT));
+
+    }
+
+    public Comment getCommentById(Long commentId) {
+        return comments.stream()
+                .filter(comment -> comment.getId().equals(commentId))
+                .findFirst()
+                .orElseThrow(() -> new MeetingExceptionHandler(ErrorCode.NOT_FOUND_COMMENT));
+    }
+
+    public void updateComment(Long commentId, UpdateCommentRequest updateCommentRequest) {
+        comments.stream()
+                .filter(comment -> comment.getId().equals(commentId))
+                .findFirst()
+                .ifPresent(comment -> {
+                    if (updateCommentRequest.getContent() != null && !updateCommentRequest.getContent().isEmpty()) {
+                        comment.setContent(updateCommentRequest.getContent());
+                        comment.setUpdated(true);
+                    }
+                });
     }
 
 }

--- a/src/main/java/com/example/gatheringhaja/exception/ErrorCode.java
+++ b/src/main/java/com/example/gatheringhaja/exception/ErrorCode.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    NO_LATEST_COMMENT(HttpStatus.NOT_FOUND, "최신 댓글이 없습니다."),
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하는 회원이 없습니다."),
+    NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, "존재하는 댓글이 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
     NOT_FOUND_LOAD_FILE(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
     NOT_FOUND_MEETING(HttpStatus.NOT_FOUND, "요청하신 모임 정보가 없습니다."),

--- a/src/main/java/com/example/gatheringhaja/service/MeetingService.java
+++ b/src/main/java/com/example/gatheringhaja/service/MeetingService.java
@@ -4,6 +4,7 @@ import com.example.gatheringhaja.dto.CommentPayload;
 import com.example.gatheringhaja.dto.MemberPayload;
 import com.example.gatheringhaja.dto.request.CreateCommentRequest;
 import com.example.gatheringhaja.dto.request.CreateMeetingRequest;
+import com.example.gatheringhaja.dto.request.UpdateCommentRequest;
 import com.example.gatheringhaja.dto.request.UpdateMeetingRequest;
 import com.example.gatheringhaja.dto.response.*;
 import com.example.gatheringhaja.entity.Comment;
@@ -77,10 +78,18 @@ public class MeetingService {
         Comment comment = createCommentRequest.toEntity();
         meeting.addComments(comment);
         meetingRepository.save(meeting);
-        Comment latestComment = meeting.getComments().stream()
-                .reduce((first, second) -> second)
-                .orElseThrow(() -> new MeetingExceptionHandler(ErrorCode.NO_LATEST_COMMENT));
-        return CreateCommentResponse.from(CommentPayload.from(latestComment));
+        return CreateCommentResponse.from(CommentPayload.from(meeting.getLatestComment()));
+    }
+
+    @Transactional
+    public UpdateCommentResponse updateComment(Long meetingId, Long commentId, UpdateCommentRequest updateCommentRequest) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new MeetingExceptionHandler(ErrorCode.NOT_FOUND_MEETING));
+        memberService.findById(updateCommentRequest.getMemberId());
+        Comment comment = meeting.getCommentById(commentId);
+        meeting.updateComment(commentId, updateCommentRequest);
+        meetingRepository.save(meeting);
+        return UpdateCommentResponse.from(comment);
     }
 
 }


### PR DESCRIPTION
### 변경사항
- UpdateCommentRequest & UpdateCommentResponse 댓글 수정 dto 추가
- MeetingController & MeetingService 클래스에 updateComment() 메서드 추가
- Meeting 클래스에 최근 댓글 조회, 댓글 ID 값을 통한 조회, 댓글 수정 기능 추가
- ErrorCode 클래스에 댓글 에러코드 추가

### 테스트
- [x] API 테스트 